### PR TITLE
Update minimum version of cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 cmake_policy(SET
   # This allows setting C_VISIBILITY_PRESET on static libraries, for
   # those who want to do this with the libprov library


### PR DESCRIPTION
Cmake 4.0 (which is now distributed in ubuntu and other distros) dropped support for cmake files that require a minimum version less than 3.5, see:
https://github.com/openssl/openssl/actions/runs/14192630435/job/39768534802

Fix it by updating the require_min_version command in CMakeLists to require at least 3.18 here